### PR TITLE
More options for other_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
-**Current Version:** 0.1.2
+**Current Version:** 0.2.0
 
 This is a simple little custom lovelace element that shows a clock and some extra timezones for Home Assistant.
 
@@ -38,7 +38,9 @@ resource:
 ## CONFIGURATION
 
 Then in your lovelace configuration edit accordingly.
-It requires you have an existing [date_time_iso](https://www.home-assistant.io/integrations/time_date/) sensor. (Actually it doesnt read note below)
+Will use browser's date/time if entity is not specified. Otherwise, entity should be an existing [date_time_iso](https://www.home-assistant.io/integrations/time_date/) sensor.
+
+The other_clocks section can contain zero or more (probably no more than 3) other clocks to display. Each clock can simply be a timezone name or an object with a tz property and optional name and weekday format (short or long). If unspecified, the name defaults to the timezone and the weekday format defaults to short.
 
 The Rest should be pretty self explanatory.
 
@@ -47,9 +49,11 @@ The Rest should be pretty self explanatory.
     #title: "My Time"
     locale: en-AU
     entity: sensor.date_time_iso
-    other_time:
-      - "America/New_York"
-      - "Australia/Sydney"
+    other_clocks:
+      - tz: "America/New_York"
+        name: "Big Apple"
+      - tz: "Australia/Sydney"
+        weekday: long
       - "America/Los_Angeles"
 ```
 

--- a/clockwork-card.js
+++ b/clockwork-card.js
@@ -69,6 +69,7 @@ class ClockWorkCard extends HTMLElement {
             var _clock = _other_clocks[i];
             var _timezone;
             var _name;
+            var _weekdayFormat = 'short';
             
             if (typeof(_clock) == 'string') {
                 _timezone = _clock;
@@ -76,6 +77,7 @@ class ClockWorkCard extends HTMLElement {
             } else if (typeof(_clock) == 'object') {
                 _timezone = _clock['tz'] || 'undefined';
                 _name = _clock['name'] || _timezone;
+                _weekdayFormat = _clock['weekday'] || 'short';
             }
                 
             //Format other timezone.
@@ -83,7 +85,7 @@ class ClockWorkCard extends HTMLElement {
                 hour: 'numeric',
                 minute: 'numeric',
                 timeZone: _timezone,
-                weekday: 'short'
+                weekday: _weekdayFormat
             }); 
             
             // List other Timezone.

--- a/clockwork-card.js
+++ b/clockwork-card.js
@@ -15,7 +15,7 @@ class ClockWorkCard extends HTMLElement {
         const config = this.config;
         const locale = config.locale;
         const _locale = locale ? locale : undefined;
-        var _other_timezones = config.other_time;
+        var _other_clocks = config.other_clocks;
         
         const entityId = config.entity;
 
@@ -60,28 +60,39 @@ class ClockWorkCard extends HTMLElement {
             month : 'long'
         });
 
-        //Build List of Other Timezones
-        //
+        //Build List of Other Clocks
         var otherclocks = `
             <div class = "other_clocks">
             `;
-        var i;
-        var j = _other_timezones.length; //TODO: Recommend max 3.
-        for (i= 0; i < j; i++) {
-            //Format other timezones.
+        // TODO: Recommend max 3.
+        for (var i = 0; i < _other_clocks.length; i++) {
+            var _clock = _other_clocks[i];
+            var _timezone;
+            var _name;
+            
+            if (typeof(_clock) == 'string') {
+                _timezone = _clock;
+                _name = _clock;
+            } else if (typeof(_clock) == 'object') {
+                _timezone = _clock['tz'] || 'undefined';
+                _name = _clock['name'] || _timezone;
+            }
+                
+            //Format other timezone.
             var _tztime = _date_time.toLocaleTimeString(_locale, {
                 hour: 'numeric',
                 minute: 'numeric',
-                timeZone: _other_timezones[i],
+                timeZone: _timezone,
                 weekday: 'short'
             }); 
             
-            // List other Timezones.
+            // List other Timezone.
             otherclocks = otherclocks + `
-                <div class="tz_locale">${_other_timezones[i]} </div> 
+                <div class="tz_locale">${_name} </div> 
                 <div class="otime"> ${_tztime} </div>
             `;
             //console.log(_tztime);
+            
         };
         otherclocks = otherclocks + `
             </div>

--- a/clockwork-card.js
+++ b/clockwork-card.js
@@ -15,7 +15,7 @@ class ClockWorkCard extends HTMLElement {
         const config = this.config;
         const locale = config.locale;
         const _locale = locale ? locale : undefined;
-        var _other_clocks = config.other_clocks;
+        var _other_clocks = config.other_clocks || config.other_time;
         
         const entityId = config.entity;
 


### PR DESCRIPTION
Made some little changes I thought useful (at least for me).

I changed the other_time section name to other_clocks (will still use other_time if present) and added some options (name and weekday format) for each clock. I've also updated the README with all the info.